### PR TITLE
Small data preparation changes (ensure sufficient active molecules in random test/val splits; do not resplit if data already loaded) and set reasonable default hyperparameters

### DIFF
--- a/main_gin.py
+++ b/main_gin.py
@@ -26,8 +26,8 @@ argparser.add_argument("--hidden_dim", type=int, default=56)
 argparser.add_argument("--learning_rate", type=float, default=0.001)
 argparser.add_argument("--dropout_p", type=float, default=0.5)
 argparser.add_argument("--epochs", type=int, default=120)
-argparser.add_argument("--batch_size", type=int, default=32)
-argparser.add_argument("--weight_decay", type=float, default=1e-6)
+argparser.add_argument("--batch_size", type=int, default=1024) # needs large batches since < 0.2% of the data is active molecules otherwise almost all batches will be all inactives
+argparser.add_argument("--weight_decay", type=float, default=5e-4) # learning from very few examples (<100 active examples total), increase regularization to avoid overfitting
 #argparser.add_argument("--random_seed", type=int, default=1)
 #argparser.add_argument("--hide_test_metric", action="store_true") # always hidden as still doing hyperparameter search at this stage
 args = argparser.parse_args()
@@ -44,15 +44,14 @@ evaluator = Evaluator(name="ogbg-molhiv") # intentionally use ogbg-molhiv evalua
 
 config = {
  'device': args.device,
- # must be valid ogb dataset id, e.g. ogbg-molhiv, ogbg-molpcba, etc
  'dataset_id': 'ogbg-pcba-aid-577',
  'num_layers': args.num_layers, # 2
  'hidden_dim': args.hidden_dim, # 56
  'dropout': args.dropout_p, # 0.50
  'learning_rate': args.learning_rate, # 0.001
  'epochs': args.epochs, # 120, this problem may need more time than ogbg-molhiv
- 'batch_size': args.batch_size,# 32
- 'weight_decay': args.weight_decay # 1e-6
+ 'batch_size': args.batch_size, # 1024 ; needs larger batches since < 0.2% of the data is active molecules otherwise almost all batches will be entirely inactive examples for that gradient descent step
+ 'weight_decay': args.weight_decay # 5e-4 ; learning from very few examples (<100 active examples total in the training data), increase regularization to avoid overfitting
 }
 device = config["device"]
 

--- a/main_gin.py
+++ b/main_gin.py
@@ -15,6 +15,7 @@ import numpy as np
 import random
 from tqdm import tqdm
 import pickle
+from pathlib import Path
 
 import argparse
 
@@ -31,7 +32,13 @@ argparser.add_argument("--weight_decay", type=float, default=1e-6)
 #argparser.add_argument("--hide_test_metric", action="store_true") # always hidden as still doing hyperparameter search at this stage
 args = argparser.parse_args()
 
-meta_dict = convert_aid_577_into_ogb_dataset()
+# check if splits already exist
+data_path = Path("local_ogbg_pcba_aid_577")
+if not data_path.exists() or not data_path.is_dir():
+    meta_dict = convert_aid_577_into_ogb_dataset()
+else:
+    # default data is available, use that
+    meta_dict = {'version': 0, 'dir_path': 'local_ogbg_pcba_aid_577/pcba_aid_577', 'binary': 'True', 'num tasks': 1, 'num classes': 2, 'task type': 'classification', 'eval metric': 'rocauc', 'add_inverse_edge': 'False', 'split': 'random-80-10-10', 'download_name': 'pcba_aid_577', 'url': 'https://snap.stanford.edu/ogb/data/graphproppred/pcba_aid_577.zip', 'has_node_attr': 'True', 'has_edge_attr': 'True', 'additional node files': 'None', 'additional edge files': 'None', 'is hetero': 'False'}
 dataset = PygGraphPropPredDataset(name="ogbg-pcba-aid-577", root="local", transform=None, meta_dict=meta_dict)
 evaluator = Evaluator(name="ogbg-molhiv") # intentionally use ogbg-molhiv evaluator for ogbg-pcba-aid-577 since we have put data in same format (single task, binary output molecular/graph property prediction)
 


### PR DESCRIPTION
- Ensure we do not randomly get too few active molecules in the test and validation splits 
  (we have very few active molecules, it is easy to randomly miss including them in a random test split)

- Reuse existing data if already loaded in OGB compatible form from raw PCBA CSV
  this allows, doing multiple training runs with randomized weights on the same data split to get performance statistics for hyperparameter values on consistent data (now the default behavior after this change)

- Note that I will almost certainly need to get additional data beyond PCBA AID 577 as there are just not enough active molecules to train, validate, and test on to learn the task, I believe.  This is just a mitigation to ensure a bare minimum while I scout out new datasets, like e.g. maybe https://pubchem.ncbi.nlm.nih.gov/bioassay/1621 which also has too few actives to use alone, so I may combine multiple such datasets. Combining multiple such dataset may make the task harder to learn though as they are measuring different things (antiviral activity through unknown mechanism vs specifically NS2bNS3 proteinase inhibition).

- Adjust hyperparameters for extremely rare positive class data regime (<0.2% active molecules, < 100 active molecules in train split to learn from)  
    - increase default batch size to 1024 as needs larger batches since < 0.2% of the data is active molecules otherwise almost all batches will be entirely inactive examples for that gradient descent step
    
    - increase default weight decay to 5e-4 as we are learning from very few examples (<100 active examples total in the training data), so we increase regularization to avoid overfitting