### PR TITLE
OGB toolkit we depend on is not yet compatible with pytorch 2.6 or later so ensure it uses older version by pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,11 @@ NOTE THERE ARE NO COMPETITIONS ASSOCIATED WITH THESE DATASETS THAT I AM AWARE OF
 
 # Trying it out
 
-1. Install dependencies (run `install_dependencies.sh` this comes with or commands below):
+1. Install dependencies (run `install_dependencies.sh`)
 
 ```
-pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-2.2.1+cu121.html
-pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-2.2.1+cu121.html
-pip install torch-geometric # I'm using 2.5.3 right now
-pip install ogb # I'm using 1.3.6 right now
+chmod +x install_dependencies.sh
+./install_dependencies.sh
 ```
 
 2. Run this script `python main_gin.py --use_scaffold_split` (I'm using python 3.10.12 but should be flexible)

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+pip install torch==2.5.1
 pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-2.2.1+cu121.html
 pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-2.2.1+cu121.html
-pip install torch-geometric
-pip install ogb
+pip install torch-geometric==2.5.3
+pip install ogb==1.3.6
 pip install rdkit
 pip install scikit-learn>=1.3
 pip install deepchem==2.8.0 # only used for scaffold splitting


### PR DESCRIPTION
See https://github.com/willy-b/tiny-GIN-for-WNV/issues/20 .