### PR TITLE
Update install_dependencies.sh - pin dependency of deepchem ( https://github.com/willy-b/tiny-GIN-for-WNV/issues/22 ) to avoid issues when downgrading torch for ogb compatibility on some machines

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+pip install torchvision==0.20.0 # invoked by deepchem dependency
+# torchvision e.g. 0.21 can be an issue if left at the higher version after downgrading torch to 2.5.1 
+# must downgrade torch to 2.5.1 to stay compatible with ogb 1.3.6, see https://github.com/snap-stanford/ogb/issues/497
 pip install torch==2.5.1
 pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-2.2.1+cu121.html
 pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-2.2.1+cu121.html


### PR DESCRIPTION
Follow up for interaction between deepchem and fix for ogb pytorch constraint in https://github.com/willy-b/tiny-GIN-for-WNV/pull/21 . 